### PR TITLE
docs: 소스코드 기반 Validator 검증 규칙 상세 반영

### DIFF
--- a/domain/cart/정책.md
+++ b/domain/cart/정책.md
@@ -10,17 +10,49 @@
 
 ---
 
-## 장바구니 생성 시 검증 (7가지)
+## CartValidator 검증 규칙 (소스코드 기반)
 
-| # | 검증 항목 | 실패 시 |
-|---|----------|--------|
-| 1 | 이벤트가 `OPEN` 상태인지 | 장바구니 생성 불가 |
-| 2 | 티켓 판매 시간 내인지 (`sale_start_at` ~ `sale_end_at`) | 판매 기간 아님 |
-| 3 | 재고가 충분한지 | 재고 부족 |
-| 4 | 1인당 구매 제한 이내인지 | 구매 제한 초과 |
-| 5 | 옵션 답변이 필수 옵션을 모두 포함하는지 | 필수 옵션 누락 |
-| 6 | 옵션 답변이 유효한 옵션 그룹에 속하는지 | 유효하지 않은 옵션 |
-| 7 | 티켓이 판매 가능(`sellable`) 상태인지 | 판매 중지됨 |
+> 소스: `DuDoong-Domain/.../cart/domain/CartValidator.kt`
+
+### validCanCreate(cart) — 장바구니 생성 검증
+
+| # | 메서드 | 검증 조건 | 실패 시 예외 |
+|---|--------|----------|-------------|
+| 1 | `validItemKindIsOneType(cart)` | `cart.getDistinctItemIds().size == 1` | `CartItemNotOneTypeException` |
+| 2 | `validCorrectAnswer(cart)` | 각 옵션 답변이 해당 Option의 유효한 선택지 | `CartInvalidOptionAnswerException` |
+| 3 | `validAnswerToAllQuestion(cart, item)` | 답변한 옵션그룹 ID == 아이템의 옵션그룹 ID | `CartNotAnswerAllOptionGroupException` |
+| 4 | `validEventIsOpen(event)` | `event.status == OPEN` | `EventNotOpenException` |
+| 5 | `validTicketingTime(event)` | `now() < event.startAt` | `EventTicketingTimeIsPassedException` |
+| 6 | `validItemStockEnough(cart, item)` | `item.quantity >= cart.getTotalQuantity()` | `TicketItemQuantityLackException` |
+| 7 | `validItemPurchaseLimit(cart, item)` | `기구매 티켓수 + 장바구니 수량 <= purchaseLimit` | `TicketPurchaseLimitException` |
+
+### 옵션 답변 검증 상세
+
+#### validCorrectAnswer — 각 답변 값의 유효성
+```
+cartLineItems.forEach { cartLineItem ->
+    cartOptionAnswers.forEach { answer ->
+        Option.validCorrectAnswer(answer.answer)  // 해당 Option이 허용하는 값인지
+    }
+}
+```
+- 객관식(SUBJECTIVE): 미리 정의된 선택지 중 하나여야 함
+- Y/N(TRUE_FALSE): "예" 또는 "아니오"
+- 주관식(OBJECTIVE): 자유 텍스트 (항상 통과)
+
+#### validAnswerToAllQuestion — 필수 옵션 전체 답변 확인
+```
+cartLineItem의 옵션그룹 ID 목록 == item의 옵션그룹 ID 목록
+→ 불일치 시 CartNotAnswerAllOptionGroupException
+```
+
+### 전체 예외 목록 (Cart 도메인)
+
+| 예외 클래스 | 메시지 | 발생 조건 |
+|------------|--------|----------|
+| `CartItemNotOneTypeException` | 여러 아이템 종류를 담을 때 | `distinctItemIds.size != 1` |
+| `CartNotAnswerAllOptionGroupException` | 모든 옵션 그룹에 답변하지 않았을 때 | 옵션그룹 ID 불일치 |
+| `CartInvalidOptionAnswerException` | 옵션 답변이 올바르지 않을 때 | Option 검증 실패 |
 
 ---
 

--- a/domain/order/정책.md
+++ b/domain/order/정책.md
@@ -56,20 +56,196 @@ READY ──────► PENDING_PAYMENT                    PENDING_APPROVE
 
 ---
 
-## 주문 생성 시 검증 (6가지)
+## OrderValidator 검증 규칙 (소스코드 기반)
 
-| # | 검증 항목 | 예외 |
-|---|----------|------|
-| 1 | 이벤트가 `OPEN` 상태인지 | 주문 불가 |
-| 2 | 티켓팅 시간 내인지 (`now() < startAt`) | `EventTicketingTimeIsPassedException` |
-| 3 | 재고 충분한지 (`supplyCount >= quantity`) | 재고 부족 |
-| 4 | 한 종류 티켓만 주문하는지 | 혼합 구매 불가 |
-| 5 | 1인당 구매 제한 이내인지 | 구매 제한 초과 |
-| 6 | 옵션 답변이 유효한지 | 옵션 불일치 |
+> 소스: `DuDoong-Domain/.../order/domain/validator/OrderValidator.kt`
 
-### 승인형 주문 추가 검증
-- 대기 중인 주문까지 포함한 **보수적** 재고/구매제한 검사
-- `validApproveOrderCreateTotalStock(order)` - 승인 대기 주문 재고 체크
+### validCanCreate(order) — 주문 생성 검증
+
+주문 생성 시 **6가지 조건**을 순서대로 검증합니다.
+
+| # | 메서드 | 검증 조건 | 실패 시 예외 |
+|---|--------|----------|-------------|
+| 1 | `validEventIsOpen(event)` | `event.status == OPEN` | `EventNotOpenException` |
+| 2 | `validTicketingTime(event)` | `now() < event.startAt` | `EventTicketingTimeIsPassedException` |
+| 3 | `validItemStockEnough(order, item)` | `item.quantity >= order.getTotalQuantity()` | `TicketItemQuantityLackException` |
+| 4 | `validItemKindIsOneType(order)` | `order.getDistinctItemIds().size == 1` | `OrdeItemNotOneTypeException` |
+| 5 | `validItemPurchaseLimit(order, item)` | `기구매 티켓수 + 주문수량 <= item.purchaseLimit` | `TicketPurchaseLimitException` |
+| 6 | `validOptionNotChange(order, item)` | 주문의 옵션그룹 ID == 아이템의 옵션그룹 ID | `OrderItemOptionChangedException` |
+
+#### 구매 제한 계산식 (결제 주문)
+```
+paidTicketCount = issuedTicketAdaptor.countPaidTicket(userId, itemId)
+totalIssuedCount = paidTicketCount + order.getTotalQuantity()
+→ totalIssuedCount <= item.purchaseLimit 이어야 통과
+```
+
+### 승인형 주문 추가 검증 (APPROVAL)
+
+| 메서드 | 검증 조건 | 실패 시 예외 |
+|--------|----------|-------------|
+| `validApproveOrderCreateTotalStock(order)` | `승인대기 주문 총수량 + 현재 주문수량 <= item.quantity` | `TicketItemQuantityLackException` |
+| `validApproveStatePurchaseLimit(order)` | `기구매 + 승인대기 + 현재 주문 <= purchaseLimit` | `ApproveWaitingOrderPurchaseLimitException` |
+
+#### 승인형 재고 계산식
+```
+approveWaitingOrders = orderAdaptor.findByEventIdAndOrderStatus(eventId, PENDING_APPROVE)
+approveWaitingTicketCount = approveWaitingOrders.sumOf { it.getTotalQuantity() }
+expectedQuantity = approveWaitingTicketCount + order.getTotalQuantity()
+→ expectedQuantity <= item.quantity 이어야 통과
+```
+
+#### 승인형 구매 제한 계산식
+```
+paidTicketCount = issuedTicketAdaptor.countPaidTicket(userId, itemId)
+approveWaitingOrders = orderAdaptor.findByEventIdAndOrderStatusAndUserId(eventId, userId, PENDING_APPROVE)
+approveWaitingTicketCount = approveWaitingOrders.filter { itemId == it.itemId }.sumOf { getTotalQuantity() }
+totalIssuedCount = paidTicketCount + approveWaitingTicketCount + order.getTotalQuantity()
+→ totalIssuedCount <= item.purchaseLimit 이어야 통과
+```
+
+### validCanConfirmPayment(order) — 결제 확인 검증
+
+| # | 검증 | 실패 시 예외 |
+|---|------|-------------|
+| 1 | `order.orderMethod == PAYMENT` | `NotPaymentOrderException` |
+| 2 | `order.orderStatus == PENDING_PAYMENT` | `NotPendingOrderException` |
+| 3 | `validCanDone()` → 이벤트/재고/옵션 **재검증** | 각 하위 예외 |
+
+> `validCanDone()`은 주문 생성 때와 동일한 검증을 **다시** 수행합니다 (이벤트 상태, 티켓팅 시간, 재고, 구매제한, 옵션 변경).
+
+### validCanApproveOrder(order) — 주문 승인 검증
+
+| # | 검증 | 실패 시 예외 |
+|---|------|-------------|
+| 1 | `order.orderMethod != PAYMENT` (= APPROVAL) | `NotApprovalOrderException` |
+| 2 | `order.orderStatus == PENDING_APPROVE` | `NotPendingOrderException` |
+| 3 | `validCanDone()` → 재검증 | 각 하위 예외 |
+| 4 | `user.isDeletedUser() == false` | `CanNotApproveDeletedUserOrderException` |
+
+> 승인 시 **탈퇴한 사용자의 주문은 승인 거부**됩니다.
+
+### validCanFreeConfirm(order) — 무료 주문 확인 검증
+
+| # | 검증 | 실패 시 예외 |
+|---|------|-------------|
+| 1 | `order.getTotalPaymentPrice() == Money.ZERO` | `NotFreeOrderException` |
+| 2 | `order.orderStatus == PENDING_PAYMENT` | `NotPendingOrderException` |
+| 3 | `validCanDone()` → 재검증 | 각 하위 예외 |
+
+### validCanCancel(order) — 관리자 취소 검증
+
+| # | 검증 | 실패 시 예외 |
+|---|------|-------------|
+| 1 | `event.isRefundDateNotPassed()` | `NotRefundAvailableDateOrderException` |
+| 2 | `orderStatus ∈ {CONFIRM, APPROVED}` | `CanNotCancelOrderException` |
+| 3 | `validCanWithDraw()` → 이벤트 OPEN + 티켓팅 시간 재검증 | 각 하위 예외 |
+
+### validCanRefund(order) — 사용자 환불 검증
+
+| # | 검증 | 실패 시 예외 |
+|---|------|-------------|
+| 1 | `event.isRefundDateNotPassed()` | `NotRefundAvailableDateOrderException` |
+| 2 | `orderStatus ∈ {CONFIRM, APPROVED}` | `CanNotRefundOrderException` |
+| 3 | `validCanWithDraw()` → 이벤트 OPEN + 티켓팅 시간 재검증 | 각 하위 예외 |
+
+### validOwner(order, currentUserId) — 소유권 검증
+
+```kotlin
+if (order.userId != currentUserId) throw NotOwnerOrderException.EXCEPTION
+```
+
+호출 시점: 결제 확인, 무료 확인, 환불
+
+### validAmountIsSameAsRequest(order, requestAmount) — 결제 금액 일치 검증
+
+```kotlin
+if (order.totalPaymentPrice != requestAmount) throw InvalidOrderException.EXCEPTION
+```
+
+호출 시점: 토스페이먼츠 결제 확인 시 (PG에서 받은 금액과 주문 금액 비교)
+
+---
+
+## 전체 예외 목록 (Order 도메인)
+
+| 예외 클래스 | 에러 코드 | 메시지 | 발생 조건 |
+|------------|----------|--------|----------|
+| `NotOwnerOrderException` | `ORDER_NOT_MINE` | 본인의 주문이 아닙니다 | 다른 사용자의 주문 접근 |
+| `InvalidOrderException` | `ORDER_NOT_VALID` | 올바르지 않은 주문입니다 | PG 결제 금액 ≠ 주문 금액 |
+| `NotPendingOrderException` | `ORDER_NOT_PENDING` | 결제,승인 대기중인 주문이 아닙니다 | 상태가 PENDING이 아닐 때 |
+| `NotSupportedOrderMethodException` | `ORDER_NOT_SUPPORTED_METHOD` | 지원하지 않는 방식의 주문입니다 | 지원하지 않는 OrderMethod |
+| `CanNotCancelOrderException` | `ORDER_CANNOT_CANCEL` | 주문을 취소할 수 없는 상태입니다 | CONFIRM/APPROVED가 아닌 상태에서 취소 |
+| `CanNotRefundOrderException` | `ORDER_CANNOT_REFUND` | 주문을 환불할 수 없는 상태입니다 | CONFIRM/APPROVED가 아닌 상태에서 환불 |
+| `CanNotRefuseOrderException` | `ORDER_CANNOT_REFUSE` | 승인 대기중인 주문을 거절할 수 없는 상태입니다 | PENDING_APPROVE가 아닌 상태에서 거절 |
+| `NotApprovalOrderException` | `ORDER_NOT_APPROVAL` | 승인 주문이 아닙니다 | PAYMENT 주문을 승인하려 할 때 |
+| `NotPaymentOrderException` | `ORDER_NOT_PAYMENT` | 결제 주문이 아닙니다 | APPROVAL 주문에 결제 확인 시 |
+| `NotFreeOrderException` | `ORDER_NOT_FREE` | 무료 주문이 아닙니다 | 금액 ≠ 0인 주문에 무료 확인 시 |
+| `NotRefundAvailableDateOrderException` | `ORDER_NOT_REFUND_DATE` | 환불을 할 수 있는 기한을 지났습니다 | 이벤트 시작 후 환불 시도 |
+| `OrderNotFoundException` | `ORDER_NOT_FOUND` | 주문을 찾을 수 없습니다 | 존재하지 않는 주문 조회 |
+| `OrderLineNotFountException` | `ORDER_LINE_NOT_FOUND` | 주문 라인을 찾을 수 없습니다 | OrderLineItem 없음 |
+| `LessThanMinmumPaymentOrderException` | `ORDER_LESS_THAN_MINIMUM` | 최소 결제금액인 1000원보다 낮은 주문입니다 | 결제 금액 < 1,000원 |
+| `OrdeItemNotOneTypeException` | `ORDER_INVALID_ITEM_KIND_POLICY` | 장바구니에 아이템을 담는 정책을 위반하였습니다 | 여러 티켓 종류 혼합 주문 |
+| `OrderItemOptionChangedException` | `ORDER_OPTION_CHANGED` | 주문 과정중 아이템의 옵션이 변화했습니다 | 주문 중 옵션 변경 감지 |
+| `CanNotApproveDeletedUserOrderException` | `CAN_NOT_DELETED_USER_APPROVE` | 유저가 탈퇴를 했습니다 | 탈퇴 사용자 주문 승인 시도 |
+| `ApproveWaitingOrderPurchaseLimitException` | `APPROVE_WAITING_PURCHASE_LIMIT` | 승인 대기중인 주문으로 인해 티켓 최대 구매 가능 횟수를 넘겼습니다 | 승인 대기 포함 구매 제한 초과 |
+
+---
+
+## 검증 호출 흐름도
+
+### 주문 생성
+```
+CreateOrderUseCase
+└─ CreateOrderService.withOutCoupon() / withCoupon()
+   └─ Order.createPaymentOrder() / createApproveOrder()
+      └─ OrderValidator.validCanCreate()
+         ├─ validEventIsOpen()
+         ├─ validTicketingTime()
+         ├─ validItemStockEnough()
+         ├─ validItemKindIsOneType()
+         ├─ validItemPurchaseLimit()
+         └─ validOptionNotChange()
+      └─ (APPROVAL만) validApproveStatePurchaseLimit()
+      └─ (APPROVAL만) validApproveOrderCreateTotalStock()
+```
+
+### 결제 확인
+```
+ConfirmOrderUseCase
+└─ OrderConfirmService.execute()
+   ├─ OrderValidator.validOwner()
+   ├─ OrderValidator.validAmountIsSameAsRequest()
+   └─ Order.confirmPayment()
+      └─ OrderValidator.validCanConfirmPayment()
+         ├─ validMethodIsPaymentOrder()
+         ├─ validStatusCanPaymentConfirm()
+         └─ validCanDone()  ← 이벤트/재고/옵션 재검증
+```
+
+### 주문 승인
+```
+ApproveOrderUseCase
+└─ Order.approve()
+   └─ OrderValidator.validCanApproveOrder()
+      ├─ validMethodIsCanApprove()
+      ├─ validStatusCanApprove()
+      ├─ validCanDone()  ← 재검증
+      └─ validUserNotDeleted()  ← 탈퇴 사용자 차단
+```
+
+### 취소/환불
+```
+CancelOrderUseCase / RefundOrderUseCase
+└─ Order.cancel() / refund()
+   ├─ (환불만) OrderValidator.validOwner()
+   └─ OrderValidator.validCanCancel() / validCanRefund()
+      ├─ validAvailableRefundDate()
+      ├─ validStatusCanCancel() / validStatusCanRefund()
+      └─ validCanWithDraw()
+         ├─ validEventIsOpen()
+         └─ validTicketingTime()
+```
 
 ---
 

--- a/domain/ticket/정책.md
+++ b/domain/ticket/정책.md
@@ -90,12 +90,37 @@ ENTRANCE_INCOMPLETE ──(QR 스캔)──► ENTRANCE_COMPLETED
 카메라 QR 스캔 → UUID 추출 → PATCH /events/{eventId}/issuedTickets/{uuid}
 ```
 
-#### 검증 규칙 (5가지)
-1. UUID로 발급 티켓 조회
-2. **이벤트 ID 교차 검증** (다른 공연 QR 차단)
-3. 이미 입장 완료된 티켓 → `IssuedTicketAlreadyEntranceException`
-4. 취소된 티켓 → `CanNotEntranceException`
-5. **매니저 이상 권한** 필요
+#### IssuedTicketValidator 검증 규칙 (소스코드 기반)
+
+> 소스: `DuDoong-Domain/.../issuedTicket/validator/IssuedTicketValidator.kt`
+
+| # | 검증 | 실패 시 예외 |
+|---|------|-------------|
+| 1 | UUID로 발급 티켓 조회 | `IssuedTicketNotFoundException` |
+| 2 | `issuedTicket.eventId == eventId` (이벤트 ID 교차 검증) | `IssuedTicketNotMatchedEventException` |
+| 3 | `issuedTicketStatus.isAfterEntrance() == false` (중복 입장 차단) | `IssuedTicketAlreadyEntranceException` |
+| 4 | `issuedTicketStatus.isCanceled() == false` (취소 티켓 차단) | `CanNotEntranceException` |
+| 5 | 호스트 **매니저 이상** 권한 | `@HostRolesAllowed` AOP |
+
+#### 입장 처리 코드
+```kotlin
+fun entrance() {
+    if (issuedTicketStatus.isCanceled()) throw CanNotEntranceException.EXCEPTION
+    if (issuedTicketStatus.isAfterEntrance()) throw IssuedTicketAlreadyEntranceException.EXCEPTION
+    issuedTicketStatus = IssuedTicketStatus.ENTRANCE_COMPLETED
+    enteredAt = LocalDateTime.now()
+    Events.raise(EntranceIssuedTicketEvent.from(this))
+}
+```
+
+#### 취소 처리 코드
+```kotlin
+fun cancel() {
+    if (!issuedTicketStatus.isBeforeEntrance()) throw CanNotCancelException.EXCEPTION
+    issuedTicketStatus = IssuedTicketStatus.CANCELED
+}
+```
+→ `ENTRANCE_INCOMPLETE` 상태에서만 취소 가능 (입장 후 취소 불가)
 
 #### 입장 취소
 - `ENTRANCE_COMPLETED` → `ENTRANCE_INCOMPLETE` 복구 가능


### PR DESCRIPTION
## Summary

- OrderValidator 16개 메서드의 검증 조건, 예외 클래스, 호출 흐름을 코드 수준으로 문서화
- CartValidator 7개 메서드 상세 반영
- IssuedTicketValidator 검증 규칙 + 실제 코드 스니펫 추가
- Order 도메인 예외 18개 전체 목록 (에러코드, 메시지, 발생조건)
- UseCase → Service → Validator 호출 흐름도 추가

## 주요 변경

### domain/order/정책.md
- `validCanCreate` 6가지 검증 → 예외 클래스명 + 검증 조건 코드 수준 명시
- 승인형 주문 재고/구매제한 **계산식** 추가
- `validCanConfirmPayment`, `validCanApproveOrder`, `validCanFreeConfirm` 등 상세
- `validCanDone()` 재검증 메커니즘 설명
- 전체 예외 18개 테이블 추가

### domain/cart/정책.md
- CartValidator `validCanCreate` 7단계 검증 → 예외 클래스명 매핑
- 옵션 답변 검증 (validCorrectAnswer, validAnswerToAllQuestion) 상세

### domain/ticket/정책.md
- IssuedTicketValidator `entrance()`, `cancel()` 실제 코드 추가
- QR 입장 검증 5가지 → 예외 클래스명 매핑

## Test plan
- [x] 마크다운 렌더링 확인
- [x] 개인정보/시크릿 포함 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)