### PR TITLE
feat: Claude Code 스킬 추가 (정책 검증 + 현황 대시보드)

### DIFF
--- a/.claude/skills/sync-status.md
+++ b/.claude/skills/sync-status.md
@@ -1,0 +1,52 @@
+---
+name: sync-status
+description: DuDoong 2.0 에픽/태스크 진행 현황 대시보드
+triggers:
+  - 현황
+  - 진행상황
+  - sync
+  - 블로커
+  - 다음 할 일
+argument-hint: ""
+---
+
+# Sync Status Skill
+
+## Purpose
+에픽/태스크 진행 현황을 파트별(디자인/백엔드/프론트)로 집계하고 블로커를 감지한다.
+
+## When to Activate
+- 유저가 "현황 알려줘", "진행상황", "지금 뭐해야해", "블로커 있어?" 등을 요청할 때
+- 스프린트 시작/종료 시점에 상태 점검할 때
+- 주간 싱크 미팅 전 현황 파악할 때
+
+## Workflow
+
+1. WorkBook 디렉토리로 이동
+2. `node tools/sync-status.mjs` 실행
+3. 결과를 유저에게 보고:
+   - 전체 진행률 (todo/wip/review/done)
+   - 에픽별 태스크 상태
+   - 파트별 상태 (D: 디자인, B: 백엔드, F: 프론트)
+   - 블로커 목록 (디자인 미완료 → 프론트 대기 등)
+   - P0 미완료 및 의사결정 필요 항목
+4. 필요시 태스크 상태 업데이트 제안
+
+## Examples
+
+```
+유저: 현황 알려줘
+→ cd DuDoong-WorkBook && node tools/sync-status.mjs
+
+유저: 블로커 있어?
+→ cd DuDoong-WorkBook && node tools/sync-status.mjs (블로커 섹션 집중 보고)
+
+유저: T02 백엔드 시작했어
+→ tasks/EP01-T02-매진티켓-구매차단.md 에서 backend: in-progress로 수정 후 sync 재실행
+```
+
+## Notes
+- 스크립트 위치: `DuDoong-WorkBook/tools/sync-status.mjs`
+- 태스크 파일: `DuDoong-WorkBook/tasks/*.md` (frontmatter 파싱)
+- 태스크 상태 변경: 해당 .md 파일의 frontmatter 직접 수정
+- 템플릿: `DuDoong-WorkBook/templates/task-template.md`

--- a/.claude/skills/verify-policy.md
+++ b/.claude/skills/verify-policy.md
@@ -1,0 +1,50 @@
+---
+name: verify-policy
+description: 정책 문서 vs 코드베이스 검증 (enum, drift, exception 체크)
+triggers:
+  - 정책 검증
+  - policy verify
+  - 할루시네이션 체크
+  - 문서 검증
+argument-hint: "[domain] [--report]"
+---
+
+# 정책 검증 Skill
+
+## Purpose
+WorkBook 정책 문서가 실제 코드베이스와 일치하는지 자동 검증한다.
+
+## When to Activate
+- 유저가 "정책 검증해줘", "문서 맞는지 확인해줘", "할루시네이션 없는지 체크" 등을 요청할 때
+- 정책 문서를 수정한 후 검증이 필요할 때
+- 코드 변경 후 정책 drift 확인이 필요할 때
+
+## Workflow
+
+1. WorkBook 디렉토리로 이동
+2. `node tools/verify-policies.mjs --report` 실행
+3. 결과를 분석하여 유저에게 보고:
+   - ✅ 통과 항목 수
+   - ⚠️ 경고 (enum 미발견, drift 등)
+   - ❌ 불일치 (코드에 있지만 정책에 없는 값)
+4. 불일치 항목이 있으면 정책 문서 수정 제안
+5. `--report` 플래그로 sync/ 폴더에 리포트 저장
+
+## Examples
+
+```
+유저: 정책 검증해줘
+→ cd DuDoong-WorkBook && node tools/verify-policies.mjs --report
+
+유저: order 도메인만 검증해
+→ cd DuDoong-WorkBook && node tools/verify-policies.mjs order
+
+유저: 할루시네이션 없는지 확인
+→ cd DuDoong-WorkBook && node tools/verify-policies.mjs --report
+```
+
+## Notes
+- 스크립트 위치: `DuDoong-WorkBook/tools/verify-policies.mjs`
+- 매핑 설정: `DuDoong-WorkBook/tools/policy-map.json`
+- 리포트 저장: `DuDoong-WorkBook/sync/verify-{date}.md`
+- build/ 디렉토리는 자동 제외됨


### PR DESCRIPTION
## Summary\n\n- `verify-policy` 스킬: \"정책 검증해줘\" → 자동으로 verify-policies.mjs 실행\n- `sync-status` 스킬: \"현황 알려줘\" → 자동으로 sync-status.mjs 실행\n\n## 트리거\n\n| 스킬 | 트리거 키워드 |\n|------|---------------|\n| verify-policy | 정책 검증, policy verify, 할루시네이션 체크, 문서 검증 |\n| sync-status | 현황, 진행상황, sync, 블로커, 다음 할 일 |\n\n## Test plan\n\n- [ ] \"정책 검증해줘\" 입력 시 스킬 활성화 확인\n- [ ] \"현황 알려줘\" 입력 시 스킬 활성화 확인\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)