### PR TITLE
docs: Claude readonly IAM 정책 추가

### DIFF
--- a/infra/iam-claude-readonly.json
+++ b/infra/iam-claude-readonly.json
@@ -1,0 +1,58 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ClaudeReadOnly",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:Describe*",
+        "elasticloadbalancing:Describe*",
+        "rds:Describe*",
+        "rds:ListTagsForResource",
+
+        "cloudwatch:GetMetricData",
+        "cloudwatch:ListMetrics",
+        "cloudwatch:DescribeAlarms",
+        "logs:GetLogEvents",
+        "logs:FilterLogEvents",
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams",
+
+        "s3:ListBucket",
+        "s3:GetBucketLocation",
+
+        "ecs:Describe*",
+        "ecs:List*",
+        "ecr:Describe*",
+        "ecr:List*",
+
+        "elasticache:Describe*",
+
+        "route53:ListHostedZones",
+        "route53:ListResourceRecordSets",
+        "acm:ListCertificates",
+        "acm:DescribeCertificate",
+
+        "wafv2:ListWebACLs",
+        "wafv2:GetWebACL",
+        "wafv2:ListRules",
+
+        "ce:GetCostAndUsage",
+        "ce:GetCostForecast",
+
+        "health:DescribeEvents",
+        "health:DescribeEventDetails",
+
+        "iam:ListUsers",
+        "iam:ListRoles",
+        "iam:GetPolicy",
+
+        "sns:ListTopics",
+        "sns:ListSubscriptions",
+        "sqs:ListQueues",
+        "sqs:GetQueueAttributes"
+      ],
+      "Resource": "*"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary\n\nAWS MCP 연동용 ReadOnly IAM 정책 파일 추가.\n\n## 포함 서비스\n\n| 카테고리 | 서비스 |\n|----------|--------|\n| 컴퓨팅 | EC2, ECS, ECR |\n| 네트워크 | VPC/서브넷/SG/NAT (ec2:Describe*), ALB |\n| DB/캐시 | RDS, ElastiCache(Redis) |\n| 모니터링 | CloudWatch 메트릭 + Logs |\n| 보안 | WAF, ACM(SSL), IAM |\n| 도메인 | Route53 |\n| 스토리지 | S3 (목록만) |\n| 비용 | Cost Explorer |\n| 기타 | SNS, SQS, AWS Health |\n\n## 사용법\n\n1. AWS IAM 콘솔 → 정책 생성 → JSON 붙여넣기\n2. 유저 생성 (`claude-readonly`) → 정책 연결\n3. `aws configure --profile claude-ro`\n4. MCP 설정에 `AWS_PROFILE: claude-ro` 지정\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)